### PR TITLE
Clean out rpmbuild dir before building

### DIFF
--- a/scripts/buildRpm.sh
+++ b/scripts/buildRpm.sh
@@ -28,7 +28,7 @@ PATH=$PATH:/usr/local/probe/bin:$PATH
 GIT_VERSION=`git rev-list --branches HEAD | wc -l`
 VERSION="1.$GIT_VERSION"
 
-
+sudo rm -rf ~/rpmbuild
 rpmdev-setuptree
 cp packaging/$PACKAGE.spec ~/rpmbuild/SPECS
 rm -f $PACKAGE-$VERSION.tar.gz


### PR DESCRIPTION
These FileIO repos don't clear out the rpmbuild directory before building their rpm, so when we run the lross bootstrap script (building and installing each rpm sequentially), we install each of the previous rpms repeatedly.  